### PR TITLE
Update `theme_barbie` so that facet titles follow the theme

### DIFF
--- a/theme_barbie.R
+++ b/theme_barbie.R
@@ -31,7 +31,7 @@ theme_barbie <- function(barbie_font = FALSE){
         title = element_text(size=20),
         panel.background = element_rect(fill = panel_color_barbie),
         panel.border = element_rect(fill = NA, color = border_color_barbie,linewidth=1.2),
-        strip.background = element_rect(fill = lighter_color_barbie, colour = light_color_barbie),
+        strip.background = element_rect(fill = lighter_color_barbie, colour = border_color_barbie),
         strip.text = element_text(colour = text_color_barbie),
         axis.title = element_text(size=17),
         axis.text = element_text(size=13,color = text_color_barbie),

--- a/theme_barbie.R
+++ b/theme_barbie.R
@@ -31,6 +31,8 @@ theme_barbie <- function(barbie_font = FALSE){
         title = element_text(size=20),
         panel.background = element_rect(fill = panel_color_barbie),
         panel.border = element_rect(fill = NA, color = border_color_barbie,linewidth=1.2),
+        strip.background = element_rect(fill = lighter_color_barbie, colour = light_color_barbie),
+        strip.text = element_text(colour = text_color_barbie),
         axis.title = element_text(size=17),
         axis.text = element_text(size=13,color = text_color_barbie),
         axis.ticks = element_line(color = border_color_barbie,linewidth=1),


### PR DESCRIPTION
I raised this as an issue here https://github.com/MatthewBJane/theme_park/issues/2

And these 2 lines fix the defaults to follow the theme. If you like it, I suggest adding to the "template" for new theme also