### PR TITLE
Fix 2 inconsistencies

### DIFF
--- a/theme_spiderman.R
+++ b/theme_spiderman.R
@@ -10,6 +10,7 @@ showtext_auto()
 text_color_spiderman    <- '#101010'
 panel_color_spiderman   <- '#de0619'
 border_color_spiderman  <- '#101010'
+light_color_spiderman <- '#e27B78'
 medium_color_spiderman <- '#e55751'
 dark_color_spiderman   <- '#601a18'
 white_color_spiderman  <-  '#fefefe'

--- a/theme_starwars.R
+++ b/theme_starwars.R
@@ -12,6 +12,7 @@ showtext_auto()
 panel_color_starwars     <- '#000000ff'
 border_color_starwars    <- '#ffffffff'
 lightmain_color_starwars <- '#eeb4d7ff'
+text_color_starwars      <- '#f1e81fff'
 goldtext_color_starwars  <- '#f1e81fff'
 darktext_color_starwars  <- '#111111ff'
 star_color_starwars      <- '#ffffffff'


### PR DESCRIPTION
Noticed that {starwars} was missing a `text_color_starwars` object, and {spiderman} was missing a `light_color_spiderman` object. Added these so that there is more consistency between the themes.